### PR TITLE
Add PWA functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,7 @@
     <meta property="og:image" content="https://isle.pizza/island.webp">
     <meta property="og:site_name" content="LEGO Island Web Port">
 
-    <link rel="manifest" href="manifest.json" />
-
+    <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="canonical" href="https://isle.pizza">
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
     <meta property="og:image" content="https://isle.pizza/island.webp">
     <meta property="og:site_name" content="LEGO Island Web Port">
 
+    <link rel="manifest" href="manifest.json" />
+
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="canonical" href="https://isle.pizza">
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+    "name": "LEGO® Island",
+    "icons": [
+      {
+        "src": "favicon.png",
+        "type": "image/png",
+        "sizes": "512x512"
+      }
+    ],
+    "start_url": "/",
+    "display": "standalone",
+    "theme_color": "#000000"
+}


### PR DESCRIPTION
This code makes the website "installable" as a PWA by adding a web manifest with the display standalone property set.

In Chrome an icon will appear in the URL bar:
![image](https://github.com/user-attachments/assets/4cf97675-d1f7-49b7-bf4a-634851b5f7ba)

The user is prompted to install it by Chrome:
![image](https://github.com/user-attachments/assets/2ef5ea28-3603-4945-8720-8612101449c2)

It then opens in a standalone window like this:
![image](https://github.com/user-attachments/assets/56c7cb56-9e5f-4f74-8b43-1b1c13c5e217)

This also means the user can search for it in the start menu and it will appear as a normal app:
![image](https://github.com/user-attachments/assets/10617dd8-53f2-4cd7-9dc6-afcf1baca77d)

This should work very similarly across other OS and browser combinations.

I have not implemented offline functionality or a built in prompt to ask the user to install as a PWA.