### PR TITLE
feat: add svg favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <!-- Sun -->
+  <rect x="4" y="1" width="1" height="3" fill="#ffff00"/>
+  <rect x="1" y="0" width="3" height="1" fill="#ffff00"/>
+  <rect x="1" y="4" width="3" height="1" fill="#ffff00"/>
+  <rect x="0" y="1" width="1" height="3" fill="#ffff00"/>
+  <rect x="1" y="1" width="3" height="3" fill="#ffff00"/>
+  <rect x="6" y="1" width="5" height="1" fill="#ffff00"/>
+  <rect x="6" y="3" width="2" height="1" fill="#ffff00"/>
+  <rect x="8" y="4" width="2" height="1" fill="#ffff00"/>
+  <rect x="5" y="5" width="1" height="1" fill="#ffff00"/>
+  <rect x="6" y="6" width="2" height="1" fill="#ffff00"/>
+  <rect x="8" y="7" width="1" height="1" fill="#ffff00"/>
+  <rect x="3" y="6" width="1" height="2" fill="#ffff00"/>
+  <rect x="4" y="8" width="1" height="2" fill="#ffff00"/>
+  <rect x="1" y="6" width="1" height="5" fill="#ffff00"/>
+  
+  <!-- Antenna -->
+  <rect x="21" y="1" width="1" height="8" fill="#000000"/>
+  <rect x="18" y="0" width="1" height="1" fill="#000000"/>
+  <rect x="19" y="1" width="1" height="1" fill="#000000"/>
+  <rect x="20" y="2" width="1" height="1" fill="#000000"/>
+  <rect x="22" y="3" width="1" height="1" fill="#000000"/>
+  <rect x="23" y="4" width="1" height="1" fill="#000000"/>
+  <rect x="24" y="5" width="1" height="1" fill="#000000"/>
+  <rect x="23" y="6" width="1" height="1" fill="#000000"/>
+  <rect x="22" y="5" width="1" height="1" fill="#000000"/>
+  <rect x="20" y="4" width="1" height="1" fill="#000000"/>
+  <rect x="19" y="3" width="1" height="1" fill="#000000"/>
+  
+  <!-- Roof -->
+  <rect x="6" y="9" width="20" height="4" fill="#ff0000"/>
+  <rect x="7" y="8" width="2" height="1" fill="#ff0000"/>
+  <rect x="11" y="8" width="2" height="1" fill="#ff0000"/>
+  <rect x="15" y="8" width="2" height="1" fill="#ff0000"/>
+  <rect x="19" y="8" width="2" height="1" fill="#ff0000"/>
+  <rect x="23" y="8" width="2" height="1" fill="#ff0000"/>
+  <rect x="5" y="10" width="1" height="3" fill="#ff0000"/>
+  <rect x="4" y="11" width="1" height="2" fill="#ff0000"/>
+  <rect x="3" y="12" width="1" height="1" fill="#ff0000"/>
+  <rect x="26" y="10" width="1" height="3" fill="#ff0000"/>
+  <rect x="27" y="11" width="1" height="2" fill="#ff0000"/>
+  <rect x="28" y="12" width="1" height="1" fill="#ff0000"/>
+  
+  <!-- Window frame -->
+  <rect x="11" y="13" width="1" height="12" fill="#000000"/>
+  <rect x="15" y="13" width="2" height="12" fill="#000000"/>
+  <rect x="20" y="13" width="1" height="12" fill="#000000"/>
+  <rect x="11" y="13" width="10" height="1" fill="#000000"/>
+  <rect x="11" y="18" width="10" height="1" fill="#000000"/>
+  <rect x="11" y="24" width="10" height="1" fill="#000000"/>
+  
+  <!-- Window pane -->
+  <rect x="12" y="14" width="3" height="4" fill="#00ffff"/>
+  <rect x="17" y="14" width="3" height="4" fill="#00ffff"/>
+  <rect x="12" y="19" width="3" height="5" fill="#00ffff"/>
+  <rect x="17" y="19" width="3" height="5" fill="#00ffff"/>
+  
+  <!-- House -->
+  <rect x="5" y="13" width="6" height="4" fill="#ffff00"/>
+  <rect x="21" y="13" width="6" height="4" fill="#ffff00"/>
+
+  <rect x="5" y="17" width="6" height="4" fill="#0000ff"/>
+  <rect x="21" y="17" width="6" height="4" fill="#0000ff"/>
+  
+  <rect x="5" y="21" width="6" height="4" fill="#ff0000"/>
+  <rect x="21" y="21" width="6" height="4" fill="#ff0000"/>
+  
+  <rect x="5" y="25" width="22" height="4" fill="#00ff00"/>
+</svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,3 +1,7 @@
+<!-- 
+  Created by Martin Joneš (https://github.com/jondycz)
+  Contributed to the isledecomp project (https://github.com/isledecomp/isle.pizza)
+-->
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
   <!-- Sun -->
   <rect x="4" y="1" width="1" height="3" fill="#ffff00"/>


### PR DESCRIPTION
This PR adds a hand-drawn SVG version of the favicon using SVG `<rect>` elements. Dimensions are pixel perfect and the color HEX values are identical. Canvas dimensions 32x32