### PR TITLE
rename "Language" string to "Version"

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,9 +687,9 @@
                         <h3 class="config-legend">Game</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label class="form-group-label">Language</label>
+                                <label class="form-group-label">Version</label>
                                 <div class="select-wrapper">
-                                     <select id="language-select" name="Language">
+                                     <select id="version-select" name="Version">
                                         <option value="da">Danish</option>
                                         <option value="el">English (1.0)</option>
                                         <option value="en" selected>English (1.1)</option>


### PR DESCRIPTION
I think this makes more sense now that we have both v1.0 and v1.1 of English and still works in the context of the actual language options.
<img width="698" alt="image" src="https://github.com/user-attachments/assets/0338960b-56f1-46cc-bb0d-f8c28a993946" />