### PR TITLE
Add HD Audio extra backed by the eo asset variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A custom web frontend for the Emscripten port of [isle-portable](https://github.
    npm install
    ```
 
-3. Obtain the game files (`isle.js` and `isle.wasm`) by building the Emscripten version of [isle-portable](https://github.com/isledecomp/isle-portable), then copy them to the project root.
+3. Obtain the game files (`isle.js` and `isle.wasm`) by building the Emscripten version of [isle-portable](https://github.com/isledecomp/isle-portable), then copy them to the project root. Also copy `isle.wasm.map` if present — the deploy script uploads it so crash reports can be symbolicated.
 
 4. Set up the LEGO Island game assets:
    ```bash

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,7 +48,7 @@ FRONTEND_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 WASM_VERSION=""
 if [ -f "$PROJECT_DIR/isle.js" ]; then
-    WASM_VERSION=$(grep -oP 'wasmVersion"\]\s*=\s*"\K[^"]+' "$PROJECT_DIR/isle.js" 2>/dev/null || echo "")
+    WASM_VERSION=$(sed -n 's/.*wasmVersion"\][[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$PROJECT_DIR/isle.js" | head -n1)
 fi
 
 echo "Environment:      $ENV"

--- a/server/src/memories.ts
+++ b/server/src/memories.ts
@@ -20,7 +20,7 @@ interface CompletionRow {
 }
 
 const VALID_LANGUAGES = new Set([
-	"da", "el", "en", "fr", "de", "it", "jp", "ko", "pt", "ru", "es",
+	"da", "el", "en", "eo", "fr", "de", "it", "jp", "ko", "pt", "ru", "es",
 ]);
 
 function isValidLanguage(lang: unknown): lang is string {

--- a/src/core/opfs.js
+++ b/src/core/opfs.js
@@ -233,6 +233,11 @@ function applyConfigToForm(form, config) {
             continue;
         }
 
+        if (key === "Language") {
+            const hdAudio = elements["HD Audio"];
+            if (hdAudio) hdAudio.checked = (config[key] === "eo");
+        }
+
         const element = elements[key];
         if (!element) continue;
 

--- a/src/lib/ConfigurePage.svelte
+++ b/src/lib/ConfigurePage.svelte
@@ -23,16 +23,17 @@
 
     // Reload config from OPFS when navigating to this page
     $: if ($currentPage === 'configure' && configForm && !$opfsDisabled) {
-        loadConfig(configForm);
+        loadConfig(configForm).then(syncLanguageLock);
     }
 
     // Reload config from OPFS after cloud sync (even if not on config page),
     // so that saveConfigFromDOM() before game launch won't overwrite it with stale form values
     $: if ($configVersion && configForm && !$opfsDisabled) {
-        loadConfig(configForm);
+        loadConfig(configForm).then(syncLanguageLock);
     }
 
     let configForm;
+    let languageLocked = false;
     let msaaSupported = false;
     let afSupported = false;
     let isTouchDevice = false;
@@ -87,6 +88,8 @@
             showOrHideGraphicsOptions();
         }
 
+        syncLanguageLock();
+
         // Check cache status
         checkCacheStatus();
 
@@ -132,6 +135,18 @@
             saveConfig(configForm, getSiFiles);
         }
         showOrHideGraphicsOptions();
+        syncLanguageLock();
+    }
+
+    function syncLanguageLock() {
+        languageLocked = document.getElementById('language-select')?.value === 'eo';
+    }
+
+    function handleHdAudioChange() {
+        const hdAudio = document.getElementById('check-hd-audio');
+        const languageSelect = document.getElementById('language-select');
+        languageSelect.value = hdAudio.checked ? 'eo' : 'en';
+        checkCacheStatus();
     }
 
     function showOrHideGraphicsOptions() {
@@ -230,6 +245,7 @@
                             {afSupported}
                             {showOrHideGraphicsOptions}
                             {checkCacheStatus}
+                            {languageLocked}
                         />
                     </div>
                     <div class:hidden={activeTab !== 'controls'}>
@@ -253,6 +269,7 @@
                             {openSection}
                             {toggleSection}
                             {handleExtensionChange}
+                            {handleHdAudioChange}
                             {handleInstall}
                             {handleUninstall}
                         />

--- a/src/lib/config/DisplayTab.svelte
+++ b/src/lib/config/DisplayTab.svelte
@@ -7,6 +7,7 @@
     export let afSupported;
     export let showOrHideGraphicsOptions;
     export let checkCacheStatus;
+    export let languageLocked;
 </script>
 
 <div class="config-tab-panel active" id="config-tab-display">
@@ -15,12 +16,17 @@
         <div class="config-card-content" class:open={openSection === 'game'}>
             <div class="form-grid">
                 <div class="form-group">
-                    <label class="form-group-label" for="language-select">Version</label>
+                    <label class="form-group-label" for="language-select">Version
+                        {#if languageLocked}
+                            <span class="tooltip-trigger">?<span class="tooltip-content">HD Audio always maps to English (1.1). Disable the HD Audio extra to change the version.</span></span>
+                        {/if}
+                    </label>
                     <div class="select-wrapper">
-                        <select id="language-select" name="Language" disabled={opfsDisabled} onchange={() => checkCacheStatus()}>
+                        <select id="language-select" name="Language" disabled={opfsDisabled || languageLocked} onchange={() => checkCacheStatus()}>
                             <option value="da">Danish</option>
                             <option value="el">English (1.0)</option>
                             <option value="en" selected>English (1.1)</option>
+                            <option value="eo" hidden>English (1.1, HD Audio)</option>
                             <option value="fr">French</option>
                             <option value="de">German</option>
                             <option value="it">Italian</option>

--- a/src/lib/config/ExtrasTab.svelte
+++ b/src/lib/config/ExtrasTab.svelte
@@ -6,6 +6,7 @@
     export let openSection;
     export let toggleSection;
     export let handleExtensionChange;
+    export let handleHdAudioChange;
     export let handleInstall;
     export let handleUninstall;
 
@@ -24,6 +25,10 @@
                 <div class="toggle-switch">
                     <label><input type="checkbox" id="check-hd-music" name="HD Music" data-not-ini="true" disabled={opfsDisabled} onchange={handleExtensionChange}><span class="toggle-slider"></span><span class="toggle-label">HD Music <span class="toggle-badge">+450MB</span></span></label>
                     <span class="tooltip-trigger">?<span class="tooltip-content">Improve the game's music with high-definition audio.</span></span>
+                </div>
+                <div class="toggle-switch">
+                    <label><input type="checkbox" id="check-hd-audio" name="HD Audio" data-not-ini="true" disabled={opfsDisabled} onchange={handleHdAudioChange}><span class="toggle-slider"></span><span class="toggle-label">HD Audio <span class="toggle-badge">+2MB</span></span></label>
+                    <span class="tooltip-trigger">?<span class="tooltip-content">Restores the game's voice-overs and sound effects from high-quality pre-release recordings. Based on the English (1.1) version.</span></span>
                 </div>
                 <div class="toggle-switch">
                     <label><input type="checkbox" id="check-widescreen-bgs" name="Widescreen Backgrounds" data-not-ini="true" disabled={opfsDisabled} onchange={handleExtensionChange}><span class="toggle-slider"></span><span class="toggle-label">Widescreen Backgrounds <span class="toggle-badge">WIP</span></span></label>
@@ -87,6 +92,10 @@
 </div>
 
 <style>
+#config-tab-extras .toggle-group {
+    gap: 7px;
+}
+
 .offline-note {
     font-size: 0.75em;
     color: #666;


### PR DESCRIPTION
Adds an **HD Audio** toggle under Extras (below HD Music) that switches the game to a rebuilt English 1.1 asset set with voice-overs and sound effects restored from the high-quality February 1997 pre-release recordings (960 replaced audio objects across 19 SI files).

The set is delivered through the existing language mechanism as variant `eo` (`localized/eo` in the asset bucket, already uploaded and verified), so streaming, offline install (per-language cache via `Vary: Accept-Language`), scene playback and share links work unchanged — no engine changes at all.

- While the toggle is on, the Version selector under Display is locked to a hidden "English (1.1, HD Audio)" option with a tooltip explaining why; turning it off returns to English (1.1). Persistence is via the `Language` key in `isle.ini`, so the checkbox restores on reload and cloud sync.
- `eo` is whitelisted in the server's `VALID_LANGUAGES` so memory completions record correctly.
- The Extensions card keeps its single-column layout with a slightly tighter rhythm so the extra toggle doesn't grow the card height. The badge shows +2MB — the actual size delta vs. the original assets, since this pack replaces files rather than adding to them.
- Also includes a small portability fix for `deploy.sh` (macOS grep has no `-P`) and a README note about `isle.wasm.map`.

The asset pack itself is built in isle-portable (see the companion PR there) from acoustically verified matches: every replacement is the same recording as shipped, confirmed by waveform correlation and mutual-coverage checks, with shipped-only artifacts (lead-in SFX, jingle tails, radio segments) spliced around the high-quality cores and repeat-reel masters cut to the takes that shipped.