### PR TITLE
Include HD Audio in Modern Mode preset

### DIFF
--- a/src/lib/ConfigurePage.svelte
+++ b/src/lib/ConfigurePage.svelte
@@ -184,7 +184,9 @@
             document.getElementById('max-allowed-extras').value = '40';
             document.getElementById('check-hd-textures').checked = true;
             document.getElementById('check-hd-music').checked = true;
+            document.getElementById('check-hd-audio').checked = true;
             document.getElementById('check-widescreen-bgs').checked = true;
+            handleHdAudioChange();
         }
         handleFormChange();
         checkCacheStatus();


### PR DESCRIPTION
The Modern Mode preset now enables the HD Audio toggle alongside HD Textures and HD Music, and applies its language switch (eo variant) the same way a manual toggle does.