### PR TITLE
Add Lighting Model option to the Graphics settings

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -673,6 +673,19 @@ body {
     gap: 20px 30px;
 }
 
+.form-grid-dense {
+    gap: 12px 24px;
+}
+
+.form-grid-dense .form-group-label {
+    font-size: 0.85em;
+    margin-bottom: 7px;
+}
+
+.form-grid-dense select {
+    padding: 7px 12px;
+}
+
 .form-group-label {
     position: relative;
     display: inline-flex;

--- a/src/lib/ConfigurePage.svelte
+++ b/src/lib/ConfigurePage.svelte
@@ -153,13 +153,16 @@
         const rendererSelect = document.getElementById('renderer-select');
         const msaaGroup = document.getElementById('msaa-select')?.closest('.form-group');
         const afGroup = document.getElementById('anisotropic-select')?.closest('.form-group');
+        const lightingGroup = document.getElementById('lighting-model-select')?.closest('.form-group');
 
         if (rendererSelect?.value === "0 0x682656f3 0x0 0x0 0x2000000") {
             if (msaaGroup) msaaGroup.style.display = 'none';
             if (afGroup) afGroup.style.display = 'none';
+            if (lightingGroup) lightingGroup.style.display = 'none';
         } else {
             if (msaaGroup && msaaSupported) msaaGroup.style.display = '';
             if (afGroup && afSupported) afGroup.style.display = '';
+            if (lightingGroup) lightingGroup.style.display = '';
         }
     }
 
@@ -174,6 +177,7 @@
             document.getElementById('tex-high').checked = true;
             document.getElementById('max-lod').value = '3.6';
             document.getElementById('max-allowed-extras').value = '20';
+            document.getElementById('lighting-model-select').value = '0';
             document.querySelectorAll('#config-tab-extras .toggle-group input[type="checkbox"]').forEach(cb => cb.checked = false);
         } else if (preset === 'modern') {
             document.getElementById('aspect-wide').checked = true;
@@ -182,6 +186,7 @@
             document.getElementById('tex-high').checked = true;
             document.getElementById('max-lod').value = '6';
             document.getElementById('max-allowed-extras').value = '40';
+            document.getElementById('lighting-model-select').value = '1';
             document.getElementById('check-hd-textures').checked = true;
             document.getElementById('check-hd-music').checked = true;
             document.getElementById('check-hd-audio').checked = true;

--- a/src/lib/config/DisplayTab.svelte
+++ b/src/lib/config/DisplayTab.svelte
@@ -155,7 +155,7 @@
     <div class="config-section-card">
         <button type="button" class="config-card-header" onclick={() => toggleSection('graphics')}>Graphics</button>
         <div class="config-card-content" class:open={openSection === 'graphics'}>
-            <div class="form-grid">
+            <div class="form-grid form-grid-dense">
                 <div class="form-group">
                     <label class="form-group-label" for="renderer-select">Renderer</label>
                     <div class="select-wrapper">
@@ -174,6 +174,15 @@
                             <option value="3" selected>Mosaic</option>
                             <option value="4">Wipe Down</option>
                             <option value="5">Windows</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="form-group-label" for="lighting-model-select">Lighting Model</label>
+                    <div class="select-wrapper">
+                        <select id="lighting-model-select" name="Lighting Model" disabled={opfsDisabled}>
+                            <option value="0" selected>DirectX 5</option>
+                            <option value="1">DirectX 8</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Companion to isledecomp/isle-portable#823.

Adds a **Lighting Model** select (DirectX 5 / DirectX 8) to the Graphics section of the configuration page, wired to the engine's new `Lighting Model` ini option:

- **DirectX 5** (default): the original 1997 runtime's lighting, including specular highlights on LEGO plastic — reverse-engineered from the DirectX 5 binaries.
- **DirectX 8**: the look of the game on newer runtimes, where Retained Mode pre-lights vertices without specular (dark matte race track).

The Classic Mode preset selects DirectX 5, Modern Mode selects DirectX 8. The option is hidden when the Software renderer is selected (not implemented there yet). The Graphics section layout is densified (three columns of label-above selects) so the card stays compact with the fifth option.

Requires an isle.wasm build containing isledecomp/isle-portable#823.